### PR TITLE
Import date in gemspec to help bundler

### DIFF
--- a/omniauth-rescuetime.gemspec
+++ b/omniauth-rescuetime.gemspec
@@ -1,3 +1,5 @@
+require 'date'
+
 Gem::Specification.new do |gem|
   gem.name    = 'omniauth-rescuetime'
   gem.version = 1.0


### PR DESCRIPTION
Closes #1.

I tested this by pointing my install at this branch, running `bundle install`, and then `bundle outdated` (which no longer crashes).